### PR TITLE
Add editorconfig settings file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs.
+#
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+[*.bat]
+end_of_line = crlf


### PR DESCRIPTION
Most Openfire plugins use these editorconfig settings. They automatically configure most IDEs to use spaces vs tabs, and a consistent endline character.