### PR TITLE
fixes #13: Compatibility with Openfire 5.0.0.

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,8 @@ Raw Property Editor Changelog
 
 <p><b>1.0.5</b> -- to be determined</p>
 <ul>
+    <li>Minimum Java requirement: 11</li>
+    <li><a href="https://github.com/igniterealtime/openfire-rawpropertyeditor-plugin/issues/13">#13</a> Compatibility with Openfire 5.0.0</li>
 </ul>
 
 <p><b>1.0.4</b> -- April 30th 2024</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,9 +5,10 @@
     <description>${project.description}</description>
     <author>Liam Gregory</author>
     <version>${project.version}</version>
-    <date>2024-04-30</date>
+    <date>2025-07-03</date>
 	<csrfProtectionEnabled>true</csrfProtectionEnabled>
-    <minServerVersion>4.8.1</minServerVersion>    
+    <minServerVersion>4.8.1</minServerVersion>
+    <minJavaVersion>11</minJavaVersion>
     <adminconsole>
         <tab id="tab-users" >
             <sidebar id="sidebar-users" >

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-	<artifactId>plugins</artifactId>
-	<groupId>org.igniterealtime.openfire</groupId>
-	<version>4.8.1</version>
+        <artifactId>plugins</artifactId>
+        <groupId>org.igniterealtime.openfire</groupId>
+        <version>4.8.1</version>
 	</parent>
 	<groupId>rawpropertyeditor</groupId>
 	<artifactId>rawpropertyeditor</artifactId>

--- a/src/web/group-propertiesplugin.jsp
+++ b/src/web/group-propertiesplugin.jsp
@@ -1,12 +1,9 @@
 <%@ taglib uri="admin" prefix="admin" %>
-<admin:FlashMessage/> 
-<%@page import="java.util.Hashtable"%>
-<%@page import="net.sf.antcontrib.logic.IfTask.ElseIf"%>
+<admin:FlashMessage/>
 
 <%@ page import="java.net.URLEncoder"%>
-<%@ page import="org.jivesoftware.util.Log"%>
 <%@ page
-	import="org.jsoup.Jsoup,org.jsoup.safety.Safelist, org.jivesoftware.openfire.XMPPServer,org.jivesoftware.openfire.plugin.RawPropertyEditorPlugin,org.jivesoftware.util.ParamUtils,org.jivesoftware.openfire.*,java.util.HashMap,java.util.Map,org.jivesoftware.util.*,org.apache.commons.text.StringEscapeUtils"
+	import="org.jsoup.Jsoup,org.jsoup.safety.Safelist, org.jivesoftware.openfire.XMPPServer,org.jivesoftware.openfire.plugin.RawPropertyEditorPlugin,org.jivesoftware.util.ParamUtils,java.util.Map,org.jivesoftware.util.*,org.apache.commons.text.StringEscapeUtils"
 	errorPage="error.jsp"%>
 
 <%@ taglib uri="http://java.sun.com/jstl/core_rt" prefix="c"%>
@@ -18,7 +15,7 @@
     String propname2 = request.getParameter("propname2");
     String propvalue2 = request.getParameter("propvalue2");
 	
-	RawPropertyEditorPlugin plugin = (RawPropertyEditorPlugin) XMPPServer.getInstance().getPluginManager().getPlugin("rawpropertyeditor");
+	RawPropertyEditorPlugin plugin = (RawPropertyEditorPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("RawPropertyEditor").orElseThrow();
 	Map<String, String> properties = null;
 
 	if (!group.isEmpty() && group != null) {
@@ -30,9 +27,7 @@
 
 	if (request.getParameter("save") != null && request.getParameter("save").equals("true")) {
 		try {
-
-			System.out.println(group + propname2 + propvalue2 + "");
-			plugin.addGroupProperties(group, propname2, propvalue2);
+            plugin.addGroupProperties(group, propname2, propvalue2);
 			properties = plugin.getGroupProperties(group);
 		} catch (Exception e) {
 
@@ -83,7 +78,6 @@
 .button:hover {
 	background-color: #E55B0A;
 	color: white;
-}
 }
 </style>
 

--- a/src/web/groupchat-propertiesplugin.jsp
+++ b/src/web/groupchat-propertiesplugin.jsp
@@ -1,12 +1,9 @@
 <%@ taglib uri="admin" prefix="admin" %>
-<admin:FlashMessage/> 
-<%@ page import="java.util.Hashtable"%>
-<%@ page import="net.sf.antcontrib.logic.IfTask.ElseIf"%>
+<admin:FlashMessage/>
 <%@ page import="org.xmpp.packet.JID" %>
 <%@ page import="java.net.URLEncoder"%>
-<%@ page import="org.jivesoftware.util.Log"%>
 <%@ page
-    import="org.jivesoftware.openfire.XMPPServer,org.jivesoftware.openfire.plugin.RawPropertyEditorPlugin,org.jivesoftware.util.ParamUtils,org.jivesoftware.openfire.*,java.util.HashMap,java.util.Map,org.jivesoftware.util.*,org.apache.commons.text.StringEscapeUtils"
+    import="org.jivesoftware.openfire.XMPPServer,org.jivesoftware.openfire.plugin.RawPropertyEditorPlugin,org.jivesoftware.util.ParamUtils,java.util.Map,org.jivesoftware.util.*,org.apache.commons.text.StringEscapeUtils"
     errorPage="error.jsp"%>
 
 <%@ taglib uri="http://java.sun.com/jstl/core_rt" prefix="c"%>
@@ -18,7 +15,7 @@
     String propname2 = request.getParameter("propname2");
     String propvalue2 = request.getParameter("propvalue2");
     
-    RawPropertyEditorPlugin plugin = (RawPropertyEditorPlugin) XMPPServer.getInstance().getPluginManager().getPlugin("rawpropertyeditor");
+    RawPropertyEditorPlugin plugin = (RawPropertyEditorPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("RawPropertyEditor").orElseThrow();
     Map<String, String> properties = null;
 
     if (roomJID != null) {
@@ -81,7 +78,6 @@
 .button:hover {
     background-color: #E55B0A;
     color: white;
-}
 }
 </style>
 

--- a/src/web/user-propertiesplugin.jsp
+++ b/src/web/user-propertiesplugin.jsp
@@ -1,12 +1,9 @@
 <%@ taglib uri="admin" prefix="admin" %>
-<admin:FlashMessage/> 
-<%@page import="java.util.Hashtable"%>
-<%@page import="net.sf.antcontrib.logic.IfTask.ElseIf"%>
+<admin:FlashMessage/>
 
 <%@ page import="java.net.URLEncoder"%>
-<%@ page import="org.jivesoftware.util.Log"%>
 <%@ page
-    import="org.jsoup.Jsoup,org.jsoup.safety.Safelist, org.jivesoftware.openfire.XMPPServer,org.jivesoftware.openfire.plugin.RawPropertyEditorPlugin,org.jivesoftware.util.ParamUtils,org.jivesoftware.openfire.*,java.util.HashMap,java.util.Map,org.jivesoftware.util.*,org.apache.commons.text.StringEscapeUtils"
+    import="org.jsoup.Jsoup,org.jsoup.safety.Safelist, org.jivesoftware.openfire.XMPPServer,org.jivesoftware.openfire.plugin.RawPropertyEditorPlugin,org.jivesoftware.util.ParamUtils,java.util.Map,org.jivesoftware.util.*,org.apache.commons.text.StringEscapeUtils"
     errorPage="error.jsp"%>
 
 <%@ taglib uri="http://java.sun.com/jstl/core_rt" prefix="c"%>
@@ -17,7 +14,7 @@
     String propname2 = request.getParameter("propname2");
     String propvalue2 = request.getParameter("propvalue2");
     
-	RawPropertyEditorPlugin plugin = (RawPropertyEditorPlugin) XMPPServer.getInstance().getPluginManager().getPlugin("rawpropertyeditor");
+	RawPropertyEditorPlugin plugin = (RawPropertyEditorPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("RawPropertyEditor").orElseThrow();
     Map<String, String> properties = null;
 
     if (!username.isEmpty() && username != null) {
@@ -29,8 +26,6 @@
 
     if (request.getParameter("save") != null && request.getParameter("save").equals("true")) {
         try {
-
-            System.out.println(username + propname2 + propvalue2 + "");
             plugin.addProperties(username, propname2, propvalue2);
             properties = plugin.getUserProperties(username);
         } catch (Exception e) {
@@ -82,7 +77,6 @@
 .button:hover {
     background-color: #E55B0A;
     color: white;
-}
 }
 </style>
 


### PR DESCRIPTION
This replaces API that was dropped in Openfire 5.0.0 with an API that is already available in the minimum server version defined by this plugin, 4.8.1.

As a result, this plugin is now compatibile with Openfire 5.0.0 (and retains compatibility with 4.8.1 and later).

This plugin now does require Java 11 or later.